### PR TITLE
Add "Retrieve and Segment" (CVPR 2026 Highlight) to 1.1 Image Understanding

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ In **Computer Vision**, RAG has been used for:
 
 | Title | Authors | Venue/Date | Links |
 |---|---|---|---|
-|🔥Retrieve and Segment: Are a Few Examples Enough to Bridge the Supervision Gap in Open-Vocabulary Segmentation? | Aravanis *et al.* | CVPR 2026 (Highlight) | [paper](https://arxiv.org/abs/2602.23339) / [code](https://github.com/TilemahosAravanis/Retrieve-and-Segment) |
+|🔥Retrieve and Segment: Are a Few Examples Enough to Bridge the Supervision Gap in Open-Vocabulary Segmentation? | Aravanis *et al.* | CVPR 2026 (Highlight) | [paper](https://openaccess.thecvf.com/content/CVPR2026/papers/Aravanis_Retrieve_and_Segment_Are_a_Few_Examples_Enough_to_Bridge_CVPR_2026_paper.pdf) / [arXiv](https://arxiv.org/abs/2602.23339) / [code](https://github.com/TilemahosAravanis/Retrieve-and-Segment) |
 |🔥Test-Time Retrieval-Augmented Adaptation for VLMs | Fan *et al.* | ICCV 2025 | [paper](https://openaccess.thecvf.com/content/ICCV2025/papers/Fan_Test-Time_Retrieval-Augmented_Adaptation_for_Vision-Language_Models_ICCV_2025_paper.pdf) |
 |🔥Retrieval-Augmented VQA for Scientific Figures (RAVQA-VLM) | Li *et al.* | AAAI 2025 | [paper](https://ojs.aaai.org/index.php/AAAI/article/view/34653)|
 | FilterRAG: Zero-Shot Informed Retrieval-Augmented Generation to Mitigate Hallucinations in VQA | Sarwar | arXiv 2025 (Sep) | [paper](https://arxiv.org/pdf/2502.18536) |

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ In **Computer Vision**, RAG has been used for:
 
 | Title | Authors | Venue/Date | Links |
 |---|---|---|---|
+|🔥Retrieve and Segment: Are a Few Examples Enough to Bridge the Supervision Gap in Open-Vocabulary Segmentation? | Aravanis *et al.* | CVPR 2026 (Highlight) | [paper](https://arxiv.org/abs/2602.23339) / [code](https://github.com/TilemahosAravanis/Retrieve-and-Segment) |
 |🔥Test-Time Retrieval-Augmented Adaptation for VLMs | Fan *et al.* | ICCV 2025 | [paper](https://openaccess.thecvf.com/content/ICCV2025/papers/Fan_Test-Time_Retrieval-Augmented_Adaptation_for_Vision-Language_Models_ICCV_2025_paper.pdf) |
 |🔥Retrieval-Augmented VQA for Scientific Figures (RAVQA-VLM) | Li *et al.* | AAAI 2025 | [paper](https://ojs.aaai.org/index.php/AAAI/article/view/34653)|
 | FilterRAG: Zero-Shot Informed Retrieval-Augmented Generation to Mitigate Hallucinations in VQA | Sarwar | arXiv 2025 (Sep) | [paper](https://arxiv.org/pdf/2502.18536) |


### PR DESCRIPTION
Adds one paper to §1.1 Image Understanding:

**Retrieve and Segment: Are a Few Examples Enough to Bridge the Supervision Gap in Open-Vocabulary Segmentation?** — Aravanis, Stojnić, Psomas, Komodakis, Tolias — CVPR 2026 (Highlight)

- Paper: https://openaccess.thecvf.com/content/CVPR2026/papers/Aravanis_Retrieve_and_Segment_Are_a_Few_Examples_Enough_to_Bridge_CVPR_2026_paper.pdf
- arXiv: https://arxiv.org/abs/2602.23339
- Code: https://github.com/TilemahosAravanis/Retrieve-and-Segment

The method retrieves a handful of labeled examples to bridge the supervision gap in open-vocabulary segmentation, which fits the RAG-for-vision scope of the list. Formatting follows the existing table style — happy to adjust it or move the entry to another section if you'd prefer.

Disclosure: I'm one of the authors. Thanks for maintaining this list!